### PR TITLE
Add Windows worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@
 ├── packer # Contains everything necessary to build the Buildbot worker AMI
 │   ├── README.md
 │   ├── build-ami.sh # Bash script to build and publis the AMI
-│   └── linux
-│       ├── Dockerfile # Dockerfile to test AMI steps locally
-│       ├── README.md
-│       ├── buildbot-worker.service # systemd service unit for Buildbot worker process
-│       ├── linux.json
-│       ├── main.tf # Terraform project to test the AMI
-│       └── self-terminate.sh # Bash script to self-terminate EC2 instances
+│   ├── linux
+│   │   ├── Dockerfile # Dockerfile to test AMI steps locally
+│   │   ├── buildbot-worker.service # systemd service unit for Buildbot worker process
+│   │   ├── linux.json
+│   │   ├── main.tf # Terraform project to test the AMI
+│   │   └── self-terminate.sh # Bash script to self-terminate EC2 instances
+│   └── windows
+│       ├── main.tf
+│       └── self-terminate.bat # Bash script to self-terminate EC2 instances
 └── templates
     └── buildbot.json.tpl
 ```

--- a/docker/master.cfg
+++ b/docker/master.cfg
@@ -36,46 +36,68 @@ class StrictHandler(GitHubEventHandler):
 ssm_client = boto3.client('ssm')
 c = BuildmasterConfig = {}
 
-worker_name = get_default_environment(ssm_client, "BUILDBOT_WORKER_USERNAME", "example-worker")
-c['workers'] = [worker.EC2LatentWorker(worker_name,
-                                       get_default_environment(ssm_client, "BUILDBOT_WORKER_PASSWORD", "pass"),
-                                       't2.medium',
-                                       ami='ami-07225c100ab116fa9',
-                                       keypair_name='buildbot-key',
-                                       subnet_id='subnet-0fc32b6dc9692fd13',
-                                       security_group_ids=['sg-048857df200b4ef4f'],
-                                       build_wait_timeout=0,
-                                       instance_profile_name='ec2_buildbot_worker_instance_profile')]
+linux_worker_name = get_default_environment(ssm_client, "BUILDBOT_LINUX_WORKER_USERNAME", "example-worker-linux")
+windows_worker_name = get_default_environment(ssm_client, "BUILDBOT_WINDOWS_WORKER_USERNAME", "example-worker-windows")
+worker_password = get_default_environment(ssm_client, "BUILDBOT_WORKER_PASSWORD", "pass")
+c['workers'] = []
 
 c['protocols'] = {'pb': {'port': os.environ.get("BUILDBOT_WORKER_PORT", 9989)}}
 
 c['change_source'] = []
 
-c['schedulers'] = []
-c['schedulers'].append(schedulers.SingleBranchScheduler(
-                            name="webhook-pull",
-                            change_filter=util.ChangeFilter(category='pull', repository="https://github.com/UnsafePointer/ruby"),
-                            treeStableTimer=None,
-                            fileIsImportant=None,
-                            builderNames=["ruby-linux"]))
-c['schedulers'].append(schedulers.ForceScheduler(
-                            name="force",
-                            builderNames=["ruby-linux"]))
+pipelines = [
+  {
+    'suffix': 'linux',
+    'workername': linux_worker_name,
+    'command': './ci/linux.sh',
+    'ami': 'ami-07225c100ab116fa9',
+    'sgs': ['sg-048857df200b4ef4f']
+  },
+  {
+    'suffix': 'windows',
+    'workername': windows_worker_name,
+    'command': 'call ./ci/windows.bat',
+    'ami': 'ami-045f8603a6a480044',
+    'sgs': ['sg-048857df200b4ef4f', 'sg-0f59e118151d0f235']
+  }
+]
 
-factory = util.BuildFactory()
-factory.addStep(steps.GitHub(repourl='http://github.com/UnsafePointer/ruby.git',
-                             mode='full'))
-factory.addStep(steps.MakeDirectory(dir="build/build"))
-factory.addStep(steps.ShellCommand(command=["cmake", ".."],
-                                   workdir="build/build"))
-factory.addStep(steps.ShellCommand(command=["make", "-j4"],
-                                   workdir="build/build"))
+c['schedulers'] = []
 
 c['builders'] = []
-c['builders'].append(
-    util.BuilderConfig(name="ruby-linux",
-      workernames=[worker_name],
-      factory=factory))
+for pipeline in pipelines:
+  workername = pipeline['workername']
+  c['workers'].append(worker.EC2LatentWorker(workername,
+                                             worker_password,
+                                             't2.medium',
+                                             ami=pipeline['ami'],
+                                             keypair_name='buildbot-key',
+                                             subnet_id='subnet-0fc32b6dc9692fd13',
+                                             security_group_ids=pipeline['sgs'],
+                                             build_wait_timeout=0,
+                                             instance_profile_name='ec2_buildbot_worker_instance_profile'))
+  builder_name = "ruby-{}".format(pipeline['suffix'])
+  c['schedulers'].append(schedulers.SingleBranchScheduler(name="webhook-pull-{}".format(pipeline['suffix']),
+                                                          change_filter=util.ChangeFilter(category='pull', repository="https://github.com/UnsafePointer/ruby"),
+                                                          treeStableTimer=None,
+                                                          fileIsImportant=None,
+                                                          builderNames=[builder_name]))
+  c['schedulers'].append(schedulers.ForceScheduler(name="force-{}".format(pipeline['suffix']),
+                                                   builderNames=[builder_name]))
+
+  factory = util.BuildFactory()
+  factory.addStep(steps.GitHub(repourl='http://github.com/UnsafePointer/ruby.git',
+                               mode='full'))
+  factory.addStep(steps.ShellCommand(command=pipeline['command'],
+                                     workdir="build"))
+  if pipeline['suffix'] == 'windows':
+      factory.addStep(steps.ShellCommand(command=["call", "self-terminate.bat"],
+                                         workdir="C:\\Users\\Administrator",
+                                         alwaysRun=True))
+
+  c['builders'].append(util.BuilderConfig(name=builder_name,
+                                          workernames=[workername],
+                                          factory=factory))
 
 context = util.Interpolate("buildbot/%(prop:buildername)s")
 gs = reporters.GitHubStatusPush(token=get_default_environment(ssm_client, "BUILDBOT_GITHUB_API_TOKEN", "not-a-real-token"),

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,9 @@ variable "buildbot_admin_username" {}
 
 variable "buildbot_admin_password" {}
 
-variable "buildbot_worker_username" {}
+variable "buildbot_linux_worker_username" {}
+
+variable "buildbot_windows_worker_username" {}
 
 variable "buildbot_worker_password" {}
 
@@ -604,10 +606,16 @@ resource "aws_ssm_parameter" "buildbot_admin_password" {
   value = var.buildbot_admin_password
 }
 
-resource "aws_ssm_parameter" "buildbot_worker_username" {
-  name  = "/buildbot/worker/worker-username"
+resource "aws_ssm_parameter" "buildbot_linux_worker_username" {
+  name  = "/buildbot/worker/linux-worker-username"
   type  = "SecureString"
-  value = var.buildbot_worker_username
+  value = var.buildbot_linux_worker_username
+}
+
+resource "aws_ssm_parameter" "buildbot_windows_worker_username" {
+  name  = "/buildbot/worker/windows-worker-username"
+  type  = "SecureString"
+  value = var.buildbot_windows_worker_username
 }
 
 resource "aws_ssm_parameter" "buildbot_worker_password" {

--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,26 @@ resource "aws_security_group" "allow_ssh_sh" {
   }
 }
 
+resource "aws_security_group" "allow_rdp_sg" {
+  name = "allow_rdp_sg"
+  vpc_id = "vpc-063d97317ad396653"
+  ingress {
+    protocol = "tcp"
+    from_port = 3389
+    to_port = 3389
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name = "allow_rdp_sg"
+  }
+}
+
 # Network Load Balancer
 
 resource "aws_lb" "buildbot_nlb" {

--- a/packer/windows/.gitignore
+++ b/packer/windows/.gitignore
@@ -1,0 +1,3 @@
+id_rsa
+id_rsa.pub
+admin_password.txt

--- a/packer/windows/main.tf
+++ b/packer/windows/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  version = "~> 2.0"
+  region = "us-east-1"
+}
+
+locals {
+  windows_ami = "ami-045f8603a6a480044"
+}
+
+resource "aws_instance" "windows" {
+  ami = local.windows_ami
+  instance_type = "t2.medium"
+  key_name = "buildbot-key"
+  subnet_id = "subnet-0fc32b6dc9692fd13"
+  iam_instance_profile = "ec2_buildbot_worker_instance_profile"
+  vpc_security_group_ids = ["sg-048857df200b4ef4f", "sg-0f59e118151d0f235"]
+}
+
+output "windows_instance_public_ic" {
+  value = aws_instance.windows.public_ip
+}

--- a/packer/windows/self-terminate.bat
+++ b/packer/windows/self-terminate.bat
@@ -1,0 +1,3 @@
+curl -s http://169.254.169.254/latest/meta-data/instance-id > instance-id.txt
+set /p INSTANCE_ID=<instance-id.txt
+aws ec2 terminate-instances --instance-ids %INSTANCE_ID%

--- a/templates/buildbot.json.tpl
+++ b/templates/buildbot.json.tpl
@@ -28,8 +28,12 @@
         "value": "ssm:///buildbot/admin-password"
       },
       {
-        "name": "BUILDBOT_WORKER_USERNAME",
-        "value": "ssm:///buildbot/worker/worker-username"
+        "name": "BUILDBOT_LINUX_WORKER_USERNAME",
+        "value": "ssm:///buildbot/worker/linux-worker-username"
+      },
+      {
+        "name": "BUILDBOT_WINDOWS_WORKER_USERNAME",
+        "value": "ssm:///buildbot/worker/windows-worker-username"
       },
       {
         "name": "BUILDBOT_WORKER_PASSWORD",


### PR DESCRIPTION
The Buildbot worker [twisted](https://github.com/twisted/twisted) process runs as a Windows service. The installation is pretty straightforward: [Launching worker as Windows service](http://docs.buildbot.net/latest/manual/installation/misc.html#launching-worker-as-windows-service), but I couldn't find a way to shutdown the EC2 instance when the service stops, [like I am doing on Linux with systemd](https://github.com/UnsafePointer/ruby.builders/blob/3f61d2f36ad341d14bdd938101470527c31253d3/packer/linux/buildbot-worker.service#L10). So instead I am relying on Buildbot to shutdown the EC2 instances at the end of the pipeline, it's awful but it works. 